### PR TITLE
Add strikethrough example syntax to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ see [Wikipedia](http://en.wikipedia.org/wiki/Markdown)
 
 **strong**
 
+~~strikethrough~~
+
 * list
 
 >block quote


### PR DESCRIPTION
The example as-is doesn't include an example of the `strikethrough` syntax. Including this will show people strikethroughs are possible in markdown, and how to do them. 

日本語あまり上手じゃないけど、ストライックスルーのexampleを盛り込んだほうがいいと思います。
