### PR TITLE
added a print/save as pdf option

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
             <div><a href="/">Markdown Live Preview</a></div>
             <div id="reset-button"><a href="#">Reset</a></div>
             <div id="copy-button"><a href="#">Copy</a></div>
+            <div id="print-button"><a href="#">Print/PDF</a></div>
             <div id="sync-button"><input type="checkbox" id="sync-scroll-checkbox"><label for="sync-scroll-checkbox">Sync scroll</label></div>
         </div>
         <div id="github"><a href="https://github.com/tanabe/markdown-live-preview"><img src="image/GitHub-Mark-Light-32px.webp"></a></div>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -70,6 +70,10 @@ header a:hover {
     margin-left: 16px;
 }
 
+#print-button {
+    margin-left: 16px;
+}
+
 #sync-button {
     margin-left: 16px;
     -webkit-user-select: none;

--- a/src/main.js
+++ b/src/main.js
@@ -238,6 +238,98 @@ This web site is using ${"`"}markedjs/marked${"`"}.
         });
     };
 
+    let openPrintWindow = () => {
+        // Get the content from the preview pane
+        let previewContent = document.querySelector('#output').innerHTML;
+        
+        // Get the GitHub markdown CSS
+        let markdownStyles = '';
+        for (let sheet of document.styleSheets) {
+            if (sheet.href && sheet.href.includes('github-markdown')) {
+                try {
+                    for (let rule of sheet.cssRules) {
+                        markdownStyles += rule.cssText + '\n';
+                    }
+                } catch (e) {
+                    // Handle cross-origin CSS
+                    markdownStyles = `@import url('${sheet.href}');`;
+                }
+                break;
+            }
+        }
+        
+        // Create a new window with the content
+        let printWindow = window.open('', '_blank', 'width=800,height=600');
+        
+        if (printWindow) {
+            printWindow.document.write(`
+                <!DOCTYPE html>
+                <html>
+                <head>
+                    <meta charset="UTF-8">
+                    <title>Markdown Preview</title>
+                    <style>
+                        ${markdownStyles}
+                        body {
+                            margin: 0;
+                            padding: 20px;
+                            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+                        }
+                        .markdown-body {
+                            box-sizing: border-box;
+                            min-width: 200px;
+                            max-width: 980px;
+                            margin: 0 auto;
+                            padding: 45px;
+                        }
+                        @media print {
+                            body {
+                                margin: 0;
+                                padding: 0;
+                            }
+                            .markdown-body {
+                                padding: 20px;
+                            }
+                            /* Avoid page breaks inside these elements */
+                            pre, blockquote, table {
+                                page-break-inside: avoid;
+                            }
+                            /* Ensure headings stay with their content */
+                            h1, h2, h3, h4, h5, h6 {
+                                page-break-after: avoid;
+                            }
+                            /* Avoid breaking lists */
+                            ul, ol {
+                                page-break-inside: avoid;
+                            }
+                        }
+                    </style>
+                </head>
+                <body>
+                    <div class="markdown-body">
+                        ${previewContent}
+                    </div>
+                </body>
+                </html>
+            `);
+            printWindow.document.close();
+            
+            // Wait for content to load before printing
+            printWindow.onload = () => {
+                printWindow.focus();
+                printWindow.print();
+            };
+        }
+    };
+
+    let setupPrintButton = () => {
+        document.querySelector("#print-button").addEventListener('click', (event) => {
+            event.preventDefault();
+            openPrintWindow();
+        });
+    };
+
+
     // ----- local state -----
 
     let loadLastContent = () => {
@@ -346,6 +438,7 @@ This web site is using ${"`"}markedjs/marked${"`"}.
     }
     setupResetButton();
     setupCopyButton(editor);
+    setupPrintButton();
 
     let scrollBarSettings = loadScrollBarSettings() || false;
     initScrollBarSync(scrollBarSettings);


### PR DESCRIPTION
Thanks for this handy little app! I also needed the option to print out the formatted version, so I added this functionality using CSS to open up a new window with only the contents of the right-hand pane. Merge if you think other people will find this useful and you like the way I did it. There are some other ways to do it that Claude suggested. I chose option number two. 

Options for Implementation:

  1. CSS @media print approach (Simplest for Print)

  - Hide the left pane using CSS when printing
  - Pros: No additional libraries, works with browser's native print
  - Cons: User could still manually select "Save as PDF" which might not format optimally

  2. Create a temporary print window (Best balance)

  - Open a new window with only the preview content
  - Use browser's print function on that window
  - Pros: Clean, no libraries needed, works for both Print and PDF
  - Cons: Popup blockers might interfere

  3. Use html2pdf.js library (Best for PDF control)

  - Client-side PDF generation from HTML
  - Pros: Full control over PDF output, page breaks, formatting
  - Cons: Adds ~300KB dependency

  4. Use jsPDF + html2canvas (More complex)

  - Screenshots the preview and converts to PDF
  - Pros: Exact visual representation
  - Cons: Larger dependencies, might have issues with long content