### PR TITLE
Add lean multi-stage Dockerfile and GitHub Actions workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,30 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# ── Stage 1: build ─────────────────────────────────────────────
+FROM node:20-alpine AS build
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+# ── Stage 2: serve ─────────────────────────────────────────────
+FROM nginx:alpine
+
+COPY --from=build /app/dist /usr/share/nginx/html
+
+RUN printf 'server {\n\
+    listen 80;\n\
+    root /usr/share/nginx/html;\n\
+    index index.html;\n\
+    location / {\n\
+        try_files $uri $uri/ /index.html;\n\
+    }\n\
+}\n' > /etc/nginx/conf.d/default.conf
+
+EXPOSE 80


### PR DESCRIPTION
I'd like to contribute with Docker support to this project. My company has a policy that restricts employees from pasting documents on external websites, so being able to self-host the tool via a Docker image makes it much more accessible in those environments — no network dependency, no data leaving the machine.

## What's included

- **`Dockerfile`** — multi-stage build to keep the final image lean (~25–40 MB):
  1. **Build** (`node:20-alpine`) — installs dependencies and runs `vite build`
  2. **Serve** (`nginx:alpine`) — copies only the `dist/` folder with a minimal SPA-friendly nginx config

- **`.github/workflows/docker.yml`** — builds and pushes the image to GHCR on every push to `main`

## Usage

```bash
docker build -t markdown-live-preview .
docker run -p 8080:80 markdown-live-preview
```

---

Feel free to close this if it doesn't fit the project's goals.