### PR TITLE
Add codicon font-face to resolve missing Monaco editor widget icons

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,3 +1,9 @@
+@font-face {
+  font-family: 'codicon';
+  src: url('https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs/base/browser/ui/codicons/codicon/codicon.ttf') format('truetype');
+  font-display: block;
+}
+
 html, body {
   color: #333;
   overflow-x: hidden;


### PR DESCRIPTION
Added the codicon font-face to resolve missing icons in the Monaco editor's `Find & Replace` and `Change All Occurrences` widgets.

Changes:

- Added codicon font via @font-face in styles.css

**Find & Replace widget**
Before:
<img width="938" height="142" alt="find and replace widget before change" src="https://github.com/user-attachments/assets/6c8239f9-d2f7-45cb-9d34-00f6718bef00" />
After:
<img width="937" height="142" alt="find and replace widget after change" src="https://github.com/user-attachments/assets/f0d00183-71e4-4ac8-92e5-791d1f50d5ea" />

**Change All Occurrences**
Before:
<img width="97" height="37" alt="change all occurrences widget before change" src="https://github.com/user-attachments/assets/75872d78-f0fa-4bef-865d-cd9b39b11989" />
After:
<img width="95" height="36" alt="change all occurrences widget after change" src="https://github.com/user-attachments/assets/7ba095cb-f0e6-4b8e-a079-2be71800c8c5" />
