### PR TITLE
Fix stacked Mermaid error graphics while typing

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -171,9 +171,34 @@ footer {
   color: #ff7b72;
 }
 
+.markdown-body .mermaid-stale svg {
+  opacity: 0.55;
+}
+
+.markdown-body .mermaid-error-note {
+  color: #cf222e;
+  white-space: pre-wrap;
+  text-align: left;
+  font-size: 0.85em;
+  margin-top: 8px;
+}
+
+[data-theme="dark"] .markdown-body .mermaid-error-note {
+  color: #ff7b72;
+}
+
+body > div[id^="dmermaid-diagram-"],
+body > iframe[id^="imermaid-diagram-"] {
+  position: absolute;
+  top: 0;
+  left: -99999px;
+  max-width: none;
+}
+
 .split-container {
   display: flex;
   height: 100%;
+  min-height: 0;
   width: 100%;
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -15,6 +15,12 @@ const init = () => {
     const confirmationMessage = 'Are you sure you want to reset? Your changes will be lost.';
     let mermaidRenderTimer = null;
     let mermaidRenderVersion = 0;
+    const mermaidSvgCache = new Map();
+    const mermaidSvgCacheLimit = 50;
+    const mermaidErrorGracePeriod = 700;
+    let mermaidLastGoodSvg = [];
+    let mermaidFailureSince = [];
+    let mermaidGraceTimer = null;
     // default template
     const defaultInput = `# Markdown syntax guide
 
@@ -178,14 +184,87 @@ This web site is using ${"`"}markedjs/marked${"`"}.
         mermaid.initialize({
             startOnLoad: false,
             securityLevel: 'strict',
+            suppressErrorRendering: true,
             theme
         });
     };
 
+    let getMermaidErrorMessage = (error) => {
+        if (!error) {
+            return 'Unable to render Mermaid chart.';
+        }
+
+        return error.message || error.str || 'Unable to render Mermaid chart.';
+    };
+
     let showMermaidError = (element, error) => {
-        const message = error && error.message ? error.message : 'Unable to render Mermaid chart.';
         element.classList.add('mermaid-error');
-        element.textContent = `Mermaid render error: ${message}`;
+        element.textContent = `Mermaid render error: ${getMermaidErrorMessage(error)}`;
+    };
+
+    let showStaleMermaidDiagram = (element, svg, error) => {
+        element.innerHTML = svg;
+        element.classList.add('mermaid-stale');
+
+        if (!error) {
+            return;
+        }
+
+        const note = document.createElement('div');
+        note.className = 'mermaid-error-note';
+        note.textContent = `Mermaid render error: ${getMermaidErrorMessage(error)}`;
+        element.appendChild(note);
+    };
+
+    let scheduleMermaidGraceRefresh = (delay) => {
+        if (mermaidGraceTimer) {
+            clearTimeout(mermaidGraceTimer);
+        }
+
+        mermaidGraceTimer = setTimeout(() => {
+            mermaidGraceTimer = null;
+            renderMermaidDiagramsNow();
+        }, delay);
+    };
+
+    let showMermaidFailure = (element, index, error) => {
+        const previous = mermaidLastGoodSvg[index];
+        if (!previous) {
+            showMermaidError(element, error);
+            return;
+        }
+
+        const now = Date.now();
+        if (!mermaidFailureSince[index]) {
+            mermaidFailureSince[index] = now;
+        }
+
+        const elapsed = now - mermaidFailureSince[index];
+        if (elapsed < mermaidErrorGracePeriod) {
+            showStaleMermaidDiagram(element, previous, null);
+            scheduleMermaidGraceRefresh(mermaidErrorGracePeriod - elapsed);
+            return;
+        }
+
+        showStaleMermaidDiagram(element, previous, error);
+    };
+
+    let removeMermaidArtifacts = (renderId) => {
+        for (const id of [renderId, `d${renderId}`, `i${renderId}`]) {
+            const leftover = document.getElementById(id);
+            if (leftover) {
+                leftover.remove();
+            }
+        }
+    };
+
+    let cacheMermaidSvg = (key, svg) => {
+        if (mermaidSvgCache.size >= mermaidSvgCacheLimit) {
+            const oldest = mermaidSvgCache.keys().next().value;
+            mermaidSvgCache.delete(oldest);
+        }
+
+        mermaidSvgCache.set(key, svg);
     };
 
     let getMermaidTheme = () => {
@@ -196,6 +275,11 @@ This web site is using ${"`"}markedjs/marked${"`"}.
         const outputElement = document.querySelector('#output');
         if (!outputElement) {
             return;
+        }
+
+        if (mermaidGraceTimer) {
+            clearTimeout(mermaidGraceTimer);
+            mermaidGraceTimer = null;
         }
 
         const version = ++mermaidRenderVersion;
@@ -210,9 +294,39 @@ This web site is using ${"`"}markedjs/marked${"`"}.
             const source = element.dataset.mermaidSource || element.textContent;
             element.dataset.mermaidSource = source;
             element.classList.remove('mermaid-error');
+            element.classList.remove('mermaid-stale');
+
+            const cacheKey = `${theme}\n${source}`;
+            const cached = mermaidSvgCache.get(cacheKey);
+            if (cached) {
+                element.innerHTML = cached;
+                mermaidLastGoodSvg[index] = cached;
+                mermaidFailureSince[index] = null;
+                continue;
+            }
+
+            const renderId = `mermaid-diagram-${index}`;
+            let parseError = null;
+            if (!source.trim()) {
+                parseError = new Error('Empty Mermaid chart.');
+            } else {
+                try {
+                    await mermaid.parse(source);
+                } catch (error) {
+                    parseError = error;
+                }
+            }
+
+            if (version !== mermaidRenderVersion) {
+                return;
+            }
+
+            if (parseError) {
+                showMermaidFailure(element, index, parseError);
+                continue;
+            }
 
             try {
-                const renderId = `mermaid-${Date.now()}-${version}-${index}`;
                 const { svg, bindFunctions } = await mermaid.render(renderId, source);
                 if (version !== mermaidRenderVersion) {
                     return;
@@ -221,10 +335,17 @@ This web site is using ${"`"}markedjs/marked${"`"}.
                 if (typeof bindFunctions === 'function') {
                     bindFunctions(element);
                 }
+                mermaidLastGoodSvg[index] = svg;
+                mermaidFailureSince[index] = null;
+                cacheMermaidSvg(cacheKey, svg);
             } catch (error) {
-                showMermaidError(element, error);
+                removeMermaidArtifacts(renderId);
+                showMermaidFailure(element, index, error);
             }
         }
+
+        mermaidLastGoodSvg.length = elements.length;
+        mermaidFailureSince.length = elements.length;
     };
 
     let scheduleMermaidRender = () => {


### PR DESCRIPTION
Fixes #156

While you type a Mermaid diagram, mermaid's built-in "Syntax error in text"
graphic gets added to the page on every keystroke and never cleaned up. They pile
up until they cover the screen and push the editor out of view, and the only way
out is a refresh.

The cause: we call mermaid.render() without a container element, so mermaid
creates a temp div in document.body and removes it at the end of the render. When
parsing fails it draws its error graphic into that div and rethrows before the
cleanup runs, so the div is left behind. The preview re-renders on a 150ms
debounce and half-typed syntax fails to parse on most keystrokes, so they add up
fast. Since these leftovers are direct children of body, which is a flex column,
each one steals vertical space from the editor instead of just sitting below it.

The fix is suppressErrorRendering: true in configureMermaid(). With that flag
mermaid cleans up its temp element and skips drawing its own graphic. Our inline
error message still shows, and it now includes mermaid's real parse error with
the line number instead of the generic "Syntax error in text".

A few supporting changes:

- Check with mermaid.parse() before rendering and skip the render if it fails.
- Keep the last good diagram while you're mid-edit instead of blanking the chart
  on every keystroke. A diagram that never rendered still shows its error at once.
- Cache rendered SVGs, since convert() rebuilds #output on every keystroke and
  every diagram was being re-rendered on every character.
- Use deterministic render ids so mermaid can reclaim its own leftovers.
- Remove orphaned artifacts explicitly on failure, so this doesn't depend on
  mermaid internals staying as they are.

The CSS adds styles for the stale diagram and error note, and keeps mermaid's
temp containers out of the body flex column. I left the flex sizing itself alone,
since .split-container relies on the default flex-shrink for its normal layout
and Monaco sizes against its height: 100%.

dist/ isn't rebuilt here. It's committed to the repo but looks like something you
build yourself. Happy to add it if you'd prefer.