### PR TITLE
fix: stop Mermaid error containers from stacking up in the body (#156)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -178,8 +178,22 @@ This web site is using ${"`"}markedjs/marked${"`"}.
         mermaid.initialize({
             startOnLoad: false,
             securityLevel: 'strict',
+            // Without this, a failed render leaves mermaid's temporary `d<renderId>`
+            // container attached to <body>. While a diagram is being typed almost every
+            // keystroke fails, so those containers stack up until they cover the page.
+            suppressErrorRendering: true,
             theme
         });
+    };
+
+    // mermaid renders into a temporary container appended to <body>. It removes that
+    // container itself on success, and on failure only when suppressErrorRendering is on.
+    // Clean up defensively so a stray container can never accumulate.
+    let removeMermaidTempElement = (renderId) => {
+        const temp = document.getElementById(`d${renderId}`);
+        if (temp) {
+            temp.remove();
+        }
     };
 
     let showMermaidError = (element, error) => {
@@ -211,8 +225,10 @@ This web site is using ${"`"}markedjs/marked${"`"}.
             element.dataset.mermaidSource = source;
             element.classList.remove('mermaid-error');
 
+            // Deterministic id: a Date.now() based one produces a fresh orphan per
+            // keystroke if mermaid ever fails to clean up after itself.
+            const renderId = `mermaid-${version}-${index}`;
             try {
-                const renderId = `mermaid-${Date.now()}-${version}-${index}`;
                 const { svg, bindFunctions } = await mermaid.render(renderId, source);
                 if (version !== mermaidRenderVersion) {
                     return;
@@ -223,6 +239,8 @@ This web site is using ${"`"}markedjs/marked${"`"}.
                 }
             } catch (error) {
                 showMermaidError(element, error);
+            } finally {
+                removeMermaidTempElement(renderId);
             }
         }
     };


### PR DESCRIPTION
Fixes #156.

## Problem

While a Mermaid diagram is being typed, most intermediate states fail to parse. On a parse error `mermaid.render` throws *before* it calls its own `removeTempElements()`:

```js
// node_modules/mermaid/dist/mermaid.core.mjs:1231
if (parseEncounteredException) {
  throw parseEncounteredException;   // throws first
}
removeTempElements();                // never reached
```

The temporary `d<renderId>` container mermaid appended to `<body>` is therefore left behind. Because `renderMermaidDiagramsNow` built the render id from `Date.now()`, every keystroke produced a new id, so mermaid's `removeExistingElements` (which matches on id) never collected the previous one either.

The containers accumulate until they cover the viewport and the editor becomes unusable, exactly as the reporter describes.

## Change

- Enable `suppressErrorRendering` so mermaid removes its temp container on failure instead of drawing its fallback "error" diagram into it.
- Make the render id deterministic (`mermaid-<version>-<index>`) so a stale container can be reclaimed rather than orphaned.
- Remove the temp container in a `finally` block as a defensive backstop.

The existing inline `Mermaid render error: ...` message inside `#output` is unchanged — that is the intended in-place error UI. The `mermaidRenderVersion` race guard and the `dataset.mermaidSource` stash are both preserved.

## Verification

Puppeteer repro that types a fence a fragment at a time, pausing past the 150ms render debounce so every intermediate state is actually rendered:

| | orphaned containers | stray height |
|---|---|---|
| before | 5 | 578px |
| after | 0 | 0px |

Regression checks, all passing: the default document's diagram renders; a permanently invalid diagram shows exactly one inline error; correcting the diagram recovers cleanly; no console errors.

### Manual reproduction

1. Clear the editor.
2. Type a mermaid fence slowly, pausing ~0.5s between fragments (the pause matters — rendering is debounced 150ms, so fast typing never triggers an intermediate render).
3. Watch `document.querySelectorAll('body > div[id^="dmermaid"]').length` — it climbs 1→5 on `main` and stays at 0 with this change.

## Note

This branch is source-only; `dist/` is not rebuilt here to avoid a large diff that would conflict with any other in-flight branch. It needs a rebuild at merge time.