### PR TITLE
Fix missing Monaco find toolbar icons

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 import Storehouse from 'storehouse-js';
-import * as monaco from 'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/+esm';
+import * as monaco from 'monaco-editor';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import mermaid from 'mermaid';


### PR DESCRIPTION
Import Monaco from the installed package so Vite bundles its CSS and icon font with valid asset URLs. The CDN bundle used a relative font URL that resolved against the site, causing icons to appear as squares.

Fixes #167